### PR TITLE
Release v0.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-github-pull-requests",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
Doing this again since the name of my last release commit didn't match the format required to trigger a release.