### PR TITLE
Bump dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
-    "@backstage/catalog-model": "^0.7.0",
-    "@backstage/core": "^0.6.0",
-    "@backstage/plugin-catalog": "^0.2.9",
-    "@backstage/theme": "^0.2.0",
+    "@backstage/catalog-model": "^0.7.1",
+    "@backstage/core": "^0.6.1",
+    "@backstage/plugin-catalog": "^0.3.1",
+    "@backstage/theme": "^0.2.3",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@octokit/rest": "^18.0.0",
@@ -40,9 +40,9 @@
     "react-use": "^15.3.6"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.4.0",
-    "@backstage/dev-utils": "^0.1.3",
-    "@backstage/test-utils": "^0.1.6",
+    "@backstage/cli": "^0.6.0",
+    "@backstage/dev-utils": "^0.1.10",
+    "@backstage/test-utils": "^0.1.7",
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@testing-library/jest-dom": "^5.10.1",

--- a/src/components/PullRequestsStatsCard/PullRequestsStatsCard.test.tsx
+++ b/src/components/PullRequestsStatsCard/PullRequestsStatsCard.test.tsx
@@ -36,7 +36,7 @@ const mockGithubAuth = {
 
 const config = {
   getOptionalConfigArray: (_: string) => [
-    { getOptionalString: (_: string) => undefined },
+    { getOptionalString: (_s: string) => undefined },
   ],
 };
 

--- a/src/components/PullRequestsTable/PullRequestsTable.test.tsx
+++ b/src/components/PullRequestsTable/PullRequestsTable.test.tsx
@@ -36,7 +36,7 @@ const mockGithubAuth = {
 
 const config = {
   getOptionalConfigArray: (_: string) => [
-    { getOptionalString: (_: string) => undefined },
+    { getOptionalString: (_s: string) => undefined },
   ],
 };
 

--- a/src/components/usePullRequests.ts
+++ b/src/components/usePullRequests.ts
@@ -98,7 +98,7 @@ export function usePullRequests({
                 created_at,
                 updated_at,
                 user,
-                state,
+                state: pr_state,
                 draft,
                 merged_at,
               }) => ({
@@ -106,7 +106,7 @@ export function usePullRequests({
                 id,
                 number,
                 title,
-                state,
+                state: pr_state,
                 draft,
                 merged: merged_at,
                 creatorNickname: user.login,

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,16 +906,16 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@backstage/catalog-client@^0.3.5":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@backstage/catalog-client/-/catalog-client-0.3.5.tgz#ead3cae312af492af237a26b053efa14bd00d475"
-  integrity sha512-+9OTAxiNacN7gDvhomcwVfskoDdEKgNHyR8O1wUPzVR+LaB8BZuTHoNs3XdFtxMt0kNqORrMtkFCL2zlPn0qWw==
+"@backstage/catalog-client@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-client/-/catalog-client-0.3.6.tgz#8b2b9f0b4af44e533dc57588ea59f3a94f1795cf"
+  integrity sha512-S19mWwT0egGw88QBWZnVunVwcBVusyorzm70i8nrKZZqfQ6iF8a9vHnhSejZjY77urWEiobO5Il0DuUSoFU8XA==
   dependencies:
-    "@backstage/catalog-model" "^0.7.0"
+    "@backstage/catalog-model" "^0.7.1"
     "@backstage/config" "^0.1.2"
     cross-fetch "^3.0.6"
 
-"@backstage/catalog-model@^0.7.0", "@backstage/catalog-model@^0.7.1":
+"@backstage/catalog-model@^0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@backstage/catalog-model/-/catalog-model-0.7.1.tgz#56089c9e027322241f621398e71c33153f2a83c8"
   integrity sha512-S3hU1RuUqBVy+Xhrr+XIybBLYaXGJTEbOG25GjePCpEujclZlMl8ZWzzsVFluZ8+ydeYERPXweuDi2l7feOHBw==
@@ -934,19 +934,19 @@
   resolved "https://registry.yarnpkg.com/@backstage/cli-common/-/cli-common-0.1.1.tgz#621f95f2e5e4aa7cca6c632c48ccb3c3d444eb8a"
   integrity sha512-JxbSUkJIXQqamgiE38MtlMn2/BdpLaqMwwi429wZfNg8upfONIrN2BW9qMb8G9CkWdI4ssUfIem1HAtDqhdDvQ==
 
-"@backstage/cli@^0.4.0":
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/@backstage/cli/-/cli-0.4.7.tgz#27221a52258d7b1e802d5ec92e9752b47d7fdc2c"
-  integrity sha512-xW+qCrqs8oJ3bAEHIW4DVgSLq9qaqfm9TKQ7o8DdcopfNNepYRV/gI4mUPXqSuZGkkZNHXRmZy+NlQJl0nn12Q==
+"@backstage/cli@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@backstage/cli/-/cli-0.6.0.tgz#3c95caea42cf20523dae9b19fd74dfa81e45737b"
+  integrity sha512-d4LfDZk3L2afxNPBNoIlNoXYfFnx5loW54HDe1dW3kSTNyK3g8g+bxXNdzqpFfroX8/GqvZbmZPC0a0aUaXAoQ==
   dependencies:
     "@backstage/cli-common" "^0.1.1"
     "@backstage/config" "^0.1.2"
-    "@backstage/config-loader" "^0.4.1"
+    "@backstage/config-loader" "^0.5.1"
     "@hot-loader/react-dom" "^16.13.0"
     "@lerna/package-graph" "^3.18.5"
     "@lerna/project" "^3.18.0"
     "@octokit/request" "^5.4.12"
-    "@rollup/plugin-commonjs" "^16.0.0"
+    "@rollup/plugin-commonjs" "^17.1.0"
     "@rollup/plugin-json" "^4.0.2"
     "@rollup/plugin-node-resolve" "^9.0.0"
     "@rollup/plugin-yaml" "^2.1.1"
@@ -961,8 +961,8 @@
     "@types/start-server-webpack-plugin" "^2.2.0"
     "@types/webpack-env" "^1.15.2"
     "@types/webpack-node-externals" "^2.5.0"
-    "@typescript-eslint/eslint-plugin" "^v3.10.1"
-    "@typescript-eslint/parser" "^v3.10.1"
+    "@typescript-eslint/eslint-plugin" "^v4.14.0"
+    "@typescript-eslint/parser" "^v4.14.0"
     "@yarnpkg/lockfile" "^1.1.0"
     bfj "^7.0.2"
     chalk "^4.0.0"
@@ -1023,18 +1023,18 @@
     yml-loader "^2.1.0"
     yn "^4.0.0"
 
-"@backstage/config-loader@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@backstage/config-loader/-/config-loader-0.4.1.tgz#4b875f85313e691d72bbb0b8805fbe6196a5f8c8"
-  integrity sha512-cGakUm+07INt5VqJTq0FTG9WJxF4tm/znPr134JSgQllCdd3GVm65gnEZZrLl3l+9Z7N3fYmjdsFljDfDXpPrA==
+"@backstage/config-loader@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@backstage/config-loader/-/config-loader-0.5.1.tgz#a80f2047e209d2f41b17ad715c632ab142385b39"
+  integrity sha512-PmwXERs5BIf77sUIg3Fhp/elkR6ELj0czmpUgP4cuEdtazi0WcmdjCUC2DjgsKJWvYggsL1o372QKHh/M5AMTQ==
   dependencies:
     "@backstage/cli-common" "^0.1.1"
     "@backstage/config" "^0.1.1"
-    ajv "^6.12.5"
+    ajv "^7.0.3"
     fs-extra "^9.0.0"
     json-schema "^0.2.5"
     json-schema-merge-allof "^0.7.0"
-    typescript-json-schema "^0.45.0"
+    typescript-json-schema "^0.47.0"
     yaml "^1.9.2"
     yup "^0.29.3"
 
@@ -1062,50 +1062,10 @@
     react-use "^15.3.3"
     zen-observable "^0.8.15"
 
-"@backstage/core@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@backstage/core/-/core-0.5.0.tgz#6ff384adc595c18c7db60b9b2d23ebbb9086ed36"
-  integrity sha512-lCxgKBavUlLYZjZmRF8A7koP4NUhK/tbdf9SaEod0miZg6JTaDoAm3dmHPyqrMBHgoRRCDTxRIxNhj/8vY87oA==
-  dependencies:
-    "@backstage/config" "^0.1.2"
-    "@backstage/core-api" "^0.2.8"
-    "@backstage/theme" "^0.2.2"
-    "@material-ui/core" "^4.11.0"
-    "@material-ui/icons" "^4.9.1"
-    "@material-ui/lab" "4.0.0-alpha.45"
-    "@types/dagre" "^0.7.44"
-    "@types/prop-types" "^15.7.3"
-    "@types/react" "^16.9"
-    "@types/react-sparklines" "^1.7.0"
-    classnames "^2.2.6"
-    clsx "^1.1.0"
-    d3-selection "^2.0.0"
-    d3-shape "^2.0.0"
-    d3-zoom "^2.0.0"
-    dagre "^0.8.5"
-    immer "^8.0.1"
-    lodash "^4.17.15"
-    material-table "^1.69.1"
-    prop-types "^15.7.2"
-    qs "^6.9.4"
-    rc-progress "^3.0.0"
-    react "^16.12.0"
-    react-dom "^16.12.0"
-    react-helmet "6.1.0"
-    react-hook-form "^6.6.0"
-    react-markdown "^5.0.2"
-    react-router "6.0.0-beta.0"
-    react-router-dom "6.0.0-beta.0"
-    react-sparklines "^1.7.0"
-    react-syntax-highlighter "^13.5.1"
-    react-use "^15.3.3"
-    remark-gfm "^1.0.0"
-    zen-observable "^0.8.15"
-
-"@backstage/core@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@backstage/core/-/core-0.6.0.tgz#28caed4d72fe19ef41dc7d11080e3f721152b4a0"
-  integrity sha512-bpYz7VczmajfvDO8PlHI2wFduiPUwC2AX5EsKEZywNiZncAI+zMw3sxvP+zdZlHOhUbvomixWqwUz12o1FV81Q==
+"@backstage/core@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@backstage/core/-/core-0.6.1.tgz#f846d4b4eb00a0db27e2bd69b963deae8279f4bb"
+  integrity sha512-+Twa5or1w3l/TcwMPrAEyinE9E8bFndNeRNCWCidMnRVzL7l1iW/kQMfFdPXLHQgQtA44AR8/zVnqxBLk6SkbQ==
   dependencies:
     "@backstage/config" "^0.1.2"
     "@backstage/core-api" "^0.2.8"
@@ -1143,15 +1103,15 @@
     remark-gfm "^1.0.0"
     zen-observable "^0.8.15"
 
-"@backstage/dev-utils@^0.1.3":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@backstage/dev-utils/-/dev-utils-0.1.9.tgz#d6585dd1c1da8b1b31283e958827ad9252a6903c"
-  integrity sha512-BUc9hfBmbvVIqTrW1PiRKIJnztRXevBq6MLbMJ1IYKQ/oiaq6ukIE5GLOvowUr7YGVrWFfMAvHcyl26GzcpeIw==
+"@backstage/dev-utils@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@backstage/dev-utils/-/dev-utils-0.1.10.tgz#e6dd7e96d1abfe300a2abdde2298cd313ab4f6ec"
+  integrity sha512-utt99idaOIxxkoketO3tRG7wjeYQEfFiKDEeZSp/wR1MWsQSwL3JeOwEZHdg/39L70UHv/WHUxj7uSUn2VZLZQ==
   dependencies:
     "@backstage/catalog-model" "^0.7.1"
-    "@backstage/core" "^0.6.0"
-    "@backstage/plugin-catalog-react" "^0.0.2"
-    "@backstage/test-utils" "^0.1.5"
+    "@backstage/core" "^0.6.1"
+    "@backstage/plugin-catalog-react" "^0.0.3"
+    "@backstage/test-utils" "^0.1.7"
     "@backstage/theme" "^0.2.3"
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"
@@ -1165,14 +1125,14 @@
     react-router "6.0.0-beta.0"
     react-router-dom "6.0.0-beta.0"
 
-"@backstage/plugin-catalog-react@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-react/-/plugin-catalog-react-0.0.2.tgz#e50da2dac9fab3a0d5973f8d1083ee2c368e5e52"
-  integrity sha512-O6aujFPRaEFTk4XlwOoswbnoHIOqMtj6ycUj6R1mNKOM4plUgGDKKhO3be69FHMJEMbiSvVe6AW+1kXaK+1LqA==
+"@backstage/plugin-catalog-react@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog-react/-/plugin-catalog-react-0.0.3.tgz#aa1d06a50c2641bd56cc46f0cc34e67ba9179456"
+  integrity sha512-T+S1LHaIWG1q/QNkDwPn2lmEVPXLH9JEB7+TgK6lo9TcgVcZn36p+J0he1hVGdhQXp23k/Yg+ToptGisC3sb9Q==
   dependencies:
-    "@backstage/catalog-client" "^0.3.5"
+    "@backstage/catalog-client" "^0.3.6"
     "@backstage/catalog-model" "^0.7.1"
-    "@backstage/core" "^0.6.0"
+    "@backstage/core" "^0.6.1"
     "@material-ui/core" "^4.11.0"
     "@types/react" "^16.9"
     react "^16.13.1"
@@ -1180,23 +1140,23 @@
     react-router-dom "6.0.0-beta.0"
     react-use "^15.3.3"
 
-"@backstage/plugin-catalog@^0.2.9":
-  version "0.2.14"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog/-/plugin-catalog-0.2.14.tgz#50a4176a55ffa543a426ec78cbc9deaecdbcf2b7"
-  integrity sha512-lDmNcC+m1zbbzYATUp5yIZ5PUp+YyBc1KKu3CCgqjLWSbJ1aJrU1N4g59euel1l2+qSW+lH76Kkp6ZYpZbSO9A==
+"@backstage/plugin-catalog@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-catalog/-/plugin-catalog-0.3.1.tgz#25d11cde4e659bb22824123407a8ed57acbdee95"
+  integrity sha512-9zijE7JJsK4M9aYjgMfGH7saN+PUwEZMhh/PIIdfhF8loEgUtsSHrlSBaCDZwyatQBaVvXXgLE6pkz7fBZXfHQ==
   dependencies:
-    "@backstage/catalog-client" "^0.3.5"
-    "@backstage/catalog-model" "^0.7.0"
-    "@backstage/core" "^0.5.0"
-    "@backstage/plugin-scaffolder" "^0.4.1"
-    "@backstage/theme" "^0.2.2"
+    "@backstage/catalog-client" "^0.3.6"
+    "@backstage/catalog-model" "^0.7.1"
+    "@backstage/core" "^0.6.1"
+    "@backstage/plugin-catalog-react" "^0.0.3"
+    "@backstage/plugin-scaffolder" "^0.5.0"
+    "@backstage/theme" "^0.2.3"
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"
     "@material-ui/lab" "4.0.0-alpha.45"
     "@types/react" "^16.9"
     classnames "^2.2.6"
     git-url-parse "^11.4.4"
-    moment "^2.26.0"
     react "^16.13.1"
     react-dom "^16.13.1"
     react-helmet "6.1.0"
@@ -1205,14 +1165,14 @@
     react-use "^15.3.3"
     swr "^0.3.0"
 
-"@backstage/plugin-scaffolder@^0.4.1":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@backstage/plugin-scaffolder/-/plugin-scaffolder-0.4.2.tgz#58159227997f7e248ce52535bc32f19fcd0990dc"
-  integrity sha512-YuyHM587Rqg6KufxfFqQdI7dsZniBM/11Aj8Q0m5ZszOpCuNmDDkR1VX8MKHTBJ709mnLAqRgArdla7FOrOAXQ==
+"@backstage/plugin-scaffolder@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-scaffolder/-/plugin-scaffolder-0.5.0.tgz#7be43092190db408ef924a563a8583081e469a49"
+  integrity sha512-/BBYqrXdcYdIcCAzHDJdVx+E3kmDE6HbBZ0IBD9Xp48MZEX0WEppZWLfDQ36l2bAweORFS+TuKSKQp5rYGHsgA==
   dependencies:
     "@backstage/catalog-model" "^0.7.1"
-    "@backstage/core" "^0.6.0"
-    "@backstage/plugin-catalog-react" "^0.0.2"
+    "@backstage/core" "^0.6.1"
+    "@backstage/plugin-catalog-react" "^0.0.3"
     "@backstage/theme" "^0.2.3"
     "@material-ui/core" "^4.11.0"
     "@material-ui/icons" "^4.9.1"
@@ -1241,14 +1201,14 @@
     react "^16.12.0"
     react-dom "^16.12.0"
 
-"@backstage/test-utils@^0.1.5", "@backstage/test-utils@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@backstage/test-utils/-/test-utils-0.1.6.tgz#35ace651f31024c91ebf9f94ccc26b92ef70e9a9"
-  integrity sha512-s2fRC05rXxv9iZjWhUuTr2ewPuvKk4COHfKp6wrHvyKsR8KQDhRAppHE0X0Iu2fT3K6hNytpxgcJln+/K5lUEg==
+"@backstage/test-utils@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@backstage/test-utils/-/test-utils-0.1.7.tgz#2aced188da8d153b9d346c56d564e18ecefd374b"
+  integrity sha512-5N1kVVhgj1zVLnwQb8sQpaIPoNc+werUcsltUV5SRFuK3djtEuHVYeHJu3YVcUY6v/Guxzowa0EW/Ojd6lIJmg==
   dependencies:
     "@backstage/core-api" "^0.2.7"
     "@backstage/test-utils-core" "^0.1.1"
-    "@backstage/theme" "^0.2.2"
+    "@backstage/theme" "^0.2.3"
     "@material-ui/core" "^4.11.0"
     "@testing-library/jest-dom" "^5.10.1"
     "@testing-library/react" "^10.4.1"
@@ -1261,7 +1221,7 @@
     react-router-dom "6.0.0-beta.0"
     zen-observable "^0.8.15"
 
-"@backstage/theme@^0.2.0", "@backstage/theme@^0.2.2", "@backstage/theme@^0.2.3":
+"@backstage/theme@^0.2.2", "@backstage/theme@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@backstage/theme/-/theme-0.2.3.tgz#434e7fbc1645221c79e414d3a1be9be8c69e1f1c"
   integrity sha512-afoozMl4BWpjj/pmp9jWvGgrmgFVhw9FlVGK71FWTCPTqBO46WCDPopdX3Ui9ZYFNDaNxN6vvmyNN4HUWzO/Ow==
@@ -1848,10 +1808,10 @@
     magic-string "^0.25.2"
     resolve "^1.11.0"
 
-"@rollup/plugin-commonjs@^16.0.0":
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-16.0.0.tgz#169004d56cd0f0a1d0f35915d31a036b0efe281f"
-  integrity sha512-LuNyypCP3msCGVQJ7ki8PqYdpjfEkE/xtFa5DqlF+7IBD0JsfMZ87C58heSwIMint58sAUZbt3ITqOmdQv/dXw==
+"@rollup/plugin-commonjs@^17.1.0":
+  version "17.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-17.1.0.tgz#757ec88737dffa8aa913eb392fade2e45aef2a2d"
+  integrity sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     commondir "^1.0.1"
@@ -2195,11 +2155,6 @@
   resolved "https://registry.yarnpkg.com/@types/dagre/-/dagre-0.7.44.tgz#8f4b796b118ca29c132da7068fbc0d0351ee5851"
   integrity sha512-N6HD+79w77ZVAaVO7JJDW5yJ9LAxM62FpgNGO9xEde+KVYjDRyhIMzfiErXpr1g0JPon9kwlBzoBK6s4fOww9Q==
 
-"@types/eslint-visitor-keys@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
-  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
-
 "@types/estree@*":
   version "0.0.46"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
@@ -2488,26 +2443,29 @@
   resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.29.11.tgz#d654a112973f5e004bf8438122bd7e56a8e5cd7e"
   integrity sha512-9cwk3c87qQKZrT251EDoibiYRILjCmxBvvcb4meofCmx1vdnNcR9gyildy5vOHASpOKMsn42CugxUvcwK5eu1g==
 
-"@typescript-eslint/eslint-plugin@^v3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.10.1.tgz#7e061338a1383f59edc204c605899f93dc2e2c8f"
-  integrity sha512-PQg0emRtzZFWq6PxBcdxRH3QIQiyFO3WCVpRL3fgj5oQS3CDs3AeAKfv4DxNhzn8ITdNJGJ4D3Qw8eAJf3lXeQ==
+"@typescript-eslint/eslint-plugin@^v4.14.0":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.1.tgz#835f64aa0a403e5e9e64c10ceaf8d05c3f015180"
+  integrity sha512-yW2epMYZSpNJXZy22Biu+fLdTG8Mn6b22kR3TqblVk50HGNV8Zya15WAXuQCr8tKw4Qf1BL4QtI6kv6PCkLoJw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "3.10.1"
+    "@typescript-eslint/experimental-utils" "4.15.1"
+    "@typescript-eslint/scope-manager" "4.15.1"
     debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
+    lodash "^4.17.15"
     regexpp "^3.0.0"
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686"
-  integrity sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==
+"@typescript-eslint/experimental-utils@4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.1.tgz#d744d1ac40570a84b447f7aa1b526368afd17eec"
+  integrity sha512-9LQRmOzBRI1iOdJorr4jEnQhadxK4c9R2aEAsm7WE/7dq8wkKD1suaV0S/JucTL8QlYUPU1y2yjqg+aGC0IQBQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/types" "3.10.1"
-    "@typescript-eslint/typescript-estree" "3.10.1"
+    "@typescript-eslint/scope-manager" "4.15.1"
+    "@typescript-eslint/types" "4.15.1"
+    "@typescript-eslint/typescript-estree" "4.15.1"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
@@ -2523,16 +2481,15 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^v3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.10.1.tgz#1883858e83e8b442627e1ac6f408925211155467"
-  integrity sha512-Ug1RcWcrJP02hmtaXVS3axPPTTPnZjupqhgj+NnZ6BCkwSImWk/283347+x9wN+lqOdK9Eo3vsyiyDHgsmiEJw==
+"@typescript-eslint/parser@^v4.14.0":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.15.1.tgz#4c91a0602733db63507e1dbf13187d6c71a153c4"
+  integrity sha512-V8eXYxNJ9QmXi5ETDguB7O9diAXlIyS+e3xzLoP/oVE4WCAjssxLIa0mqCLsCGXulYJUfT+GV70Jv1vHsdKwtA==
   dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "3.10.1"
-    "@typescript-eslint/types" "3.10.1"
-    "@typescript-eslint/typescript-estree" "3.10.1"
-    eslint-visitor-keys "^1.1.0"
+    "@typescript-eslint/scope-manager" "4.15.1"
+    "@typescript-eslint/types" "4.15.1"
+    "@typescript-eslint/typescript-estree" "4.15.1"
+    debug "^4.1.1"
 
 "@typescript-eslint/scope-manager@4.15.0":
   version "4.15.0"
@@ -2542,29 +2499,23 @@
     "@typescript-eslint/types" "4.15.0"
     "@typescript-eslint/visitor-keys" "4.15.0"
 
-"@typescript-eslint/types@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
-  integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
+"@typescript-eslint/scope-manager@4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.15.1.tgz#f6511eb38def2a8a6be600c530c243bbb56ac135"
+  integrity sha512-ibQrTFcAm7yG4C1iwpIYK7vDnFg+fKaZVfvyOm3sNsGAerKfwPVFtYft5EbjzByDJ4dj1WD8/34REJfw/9wdVA==
+  dependencies:
+    "@typescript-eslint/types" "4.15.1"
+    "@typescript-eslint/visitor-keys" "4.15.1"
 
 "@typescript-eslint/types@4.15.0":
   version "4.15.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.15.0.tgz#3011ae1ac3299bb9a5ac56bdd297cccf679d3662"
   integrity sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==
 
-"@typescript-eslint/typescript-estree@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz#fd0061cc38add4fad45136d654408569f365b853"
-  integrity sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==
-  dependencies:
-    "@typescript-eslint/types" "3.10.1"
-    "@typescript-eslint/visitor-keys" "3.10.1"
-    debug "^4.1.1"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+"@typescript-eslint/types@4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.15.1.tgz#da702f544ef1afae4bc98da699eaecd49cf31c8c"
+  integrity sha512-iGsaUyWFyLz0mHfXhX4zO6P7O3sExQpBJ2dgXB0G5g/8PRVfBBsmQIc3r83ranEQTALLR3Vko/fnCIVqmH+mPw==
 
 "@typescript-eslint/typescript-estree@4.15.0":
   version "4.15.0"
@@ -2579,12 +2530,18 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/visitor-keys@3.10.1":
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931"
-  integrity sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==
+"@typescript-eslint/typescript-estree@4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.1.tgz#fa9a9ff88b4a04d901ddbe5b248bc0a00cd610be"
+  integrity sha512-z8MN3CicTEumrWAEB2e2CcoZa3KP9+SMYLIA2aM49XW3cWIaiVSOAGq30ffR5XHxRirqE90fgLw3e6WmNx5uNw==
   dependencies:
-    eslint-visitor-keys "^1.1.0"
+    "@typescript-eslint/types" "4.15.1"
+    "@typescript-eslint/visitor-keys" "4.15.1"
+    debug "^4.1.1"
+    globby "^11.0.1"
+    is-glob "^4.0.1"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
 
 "@typescript-eslint/visitor-keys@4.15.0":
   version "4.15.0"
@@ -2592,6 +2549,14 @@
   integrity sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==
   dependencies:
     "@typescript-eslint/types" "4.15.0"
+    eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.1.tgz#c76abbf2a3be8a70ed760f0e5756bf62de5865dd"
+  integrity sha512-tYzaTP9plooRJY8eNlpAewTOqtWW/4ff/5wBjNVaJ0S0wC4Gpq/zDVRTJa5bq2v1pCNQ08xxMCndcvR+h7lMww==
+  dependencies:
+    "@typescript-eslint/types" "4.15.1"
     eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.9.0":
@@ -12696,10 +12661,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-json-schema@^0.45.0:
-  version "0.45.1"
-  resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.45.1.tgz#d3c1feea85b3bfeaf7e42a8c3bab80f2dc121a5d"
-  integrity sha512-Iz1NKVtJi09iZSzXj3J350GekBrZ1TiNw6Cbf42jLOGyooh9BWoi8XP6XlTIMOI3aMD8XxuL9hEvIEq8FD/WUw==
+typescript-json-schema@^0.47.0:
+  version "0.47.0"
+  resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.47.0.tgz#84dde5460b127c6774da81bf70b23c7e04857b13"
+  integrity sha512-A6NVwSOTSsNDHfaqDcDeKwwyXEeKqBHoAr20jcetnYj4e8C6zVFofAVhAuwsBXCRYiWEE/lyHrcxpsSpbIk0Mg==
   dependencies:
     "@types/json-schema" "^7.0.6"
     glob "^7.1.6"


### PR DESCRIPTION
Similar to https://github.com/RoadieHQ/backstage-plugin-buildkite/pull/29

We are using this plugin with newer backstage modules and need to bump the versions here to fix some inconsistencies.