### PR TITLE
updating plugin catalog version and bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-github-pull-requests",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
   "dependencies": {
     "@backstage/catalog-model": "^0.7.1",
     "@backstage/core": "^0.6.1",
-    "@backstage/plugin-catalog": "^0.3.1",
+    "@backstage/plugin-catalog": "^0.4.0",
     "@backstage/theme": "^0.2.3",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",


### PR DESCRIPTION
upgrading dependency on plugin-catalog to fix https://github.com/RoadieHQ/backstage-plugin-github-pull-requests/issues/73