### PR TITLE
Add variant support to PullRequestStatsCard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-github-pull-requests",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/components/PullRequestsStatsCard/PullRequestsStatsCard.tsx
+++ b/src/components/PullRequestsStatsCard/PullRequestsStatsCard.tsx
@@ -15,7 +15,11 @@
  */
 
 import React, { useState } from 'react';
-import { InfoCard, StructuredMetadataTable } from '@backstage/core';
+import {
+  InfoCard,
+  InfoCardVariants,
+  StructuredMetadataTable
+} from '@backstage/core';
 import { useProjectName } from '../useProjectName';
 import { usePullRequestsStatistics } from '../usePullRequestsStatistics';
 import {
@@ -48,9 +52,10 @@ const useStyles = makeStyles(theme => ({
 type Props = {
   /** @deprecated The entity is now grabbed from context instead */
   entity?: Entity;
+  variant?: InfoCardVariants;
 };
 
-const PullRequestsStatsCard = (_props: Props) => {
+const PullRequestsStatsCard = (props: Props) => {
   const { entity } = useEntity();
   const classes = useStyles();
   const [pageSize, setPageSize] = useState<number>(20);
@@ -71,7 +76,8 @@ const PullRequestsStatsCard = (_props: Props) => {
   };
 
   return (
-    <InfoCard title="Pull requests statistics" className={classes.infoCard}>
+    <InfoCard
+      title="Pull requests statistics" className={classes.infoCard} variant={props.variant}>
       {loadingStatistics ? (
         <CircularProgress />
       ) : (


### PR DESCRIPTION
Add support for the [InfoCardVariants](https://github.com/backstage/backstage/blob/master/packages/core/src/layout/InfoCard/InfoCard.tsx#L62-L90) to the PullRequestStatsCard. This can help with layout, e.g. making the card full height to fit nicer with other cards in a grid.

E.g.

```ts
<Grid item xs={8}>
  <JenkinsLatestRunCard branch="main" />
</Grid>
<Grid item xs={4}>
  <PullRequestsStatsCard variant="fullHeight" />
</Grid>
```

Before:
![image](https://user-images.githubusercontent.com/14176917/114588860-0c88be80-9c7f-11eb-8e64-21925d8f0cce.png)

After:
![image](https://user-images.githubusercontent.com/14176917/114588795-f7ac2b00-9c7e-11eb-989f-481b71c75052.png)
